### PR TITLE
just "rsync(1)" not "GNU rsync(1)"

### DIFF
--- a/openrsync.1
+++ b/openrsync.1
@@ -115,7 +115,7 @@ To update the out-of-date remote files in
 .Pa host:dest
 on a remote host running
 .Nm
-with the local host running GNU
+with the local host running
 .Xr rsync 1 :
 .Pp
 .Dl % rsync -t --checksum-choice=md5 ../dest/* host:dest


### PR DESCRIPTION
The original rsync isn't a GNU project