### PR TITLE
Remove debug option -g

### DIFF
--- a/configure
+++ b/configure
@@ -61,7 +61,7 @@ echo "config.log: writing..."
 
 CC=`printf "all:\\n\\t@echo \\\$(CC)\\n" | make -sf -`
 CFLAGS=`printf "all:\\n\\t@echo \\\$(CFLAGS)\\n" | make -sf -`
-CFLAGS="${CFLAGS} -g -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes"
+CFLAGS="${CFLAGS} -W -Wall -Wextra -Wmissing-prototypes -Wstrict-prototypes"
 CFLAGS="${CFLAGS} -Wwrite-strings -Wno-unused-parameter"
 LDADD=
 LDADD_B64_NTOP=


### PR DESCRIPTION
Currently `-g` is always added to `CFLAGS`. This is a debug option and should only be added by user via `CFLAGS` or debug switch (e.g. add a `--debug` option to `configure`).

This PR removes the debug option. An alternative fix for this issue is to add a `--release` option to `configure` and only add `-g` when it is not present.