### PR TITLE
Fix 24bit limit in rsync.5 man page

### DIFF
--- a/rsync.5
+++ b/rsync.5
@@ -93,7 +93,7 @@ Otherwise, the payload is out-of-band server messages.
 If the tag is 1, it is an error on the sender's part and must trigger an
 exit.
 This limits message payloads to 24 bit integer size,
-.Li 0x0fffffff .
+.Li 0x00ffffff .
 .Pp
 The only data not using this envelope are the initial handshake between
 client and server.


### PR DESCRIPTION
`(1<<24) - 1 = 0x00ffffff`