### PR TITLE
Build on GNU Hurd.

### DIFF
--- a/configure
+++ b/configure
@@ -519,7 +519,7 @@ cat << __HEREDOC__
 #if !defined(__GNUC__) || (__GNUC__ < 4)
 # define __attribute__(x)
 #endif
-#if defined(__linux__) || defined(__MINT__) || defined(__wasi__)
+#if defined(__linux__) || defined(__MINT__) || defined(__wasi__) || defined(__GNU__)
 # define _GNU_SOURCE /* memmem, memrchr, setresuid... */
 # define _DEFAULT_SOURCE /* le32toh, crypt, ... */
 #endif


### PR DESCRIPTION
This oneliner makes openrsync build on GNU Hurd, which needs `_GNU_SOURCE` set, the same as Linux.